### PR TITLE
add fill sprint by their user stories endpoint

### DIFF
--- a/app/api/userStory/routes.py
+++ b/app/api/userStory/routes.py
@@ -1,6 +1,7 @@
 from app.api.sprint.service.create_sprint import create_sprint_
 from app.api.userStory.schema import CreateUserStoryRequest, CreateUserStoryResponse
 from app.api.userStory.service.create_user_story import create_user_story_
+from app.api.userStory.service.fill_sprint_by_their_user_stories_ import fill_sprint_by_their_user_stories_
 from app.api.userStory.service.get_backlog_list import get_backlog_list_
 from app.api.userStory.service.get_current_user_story import get_current_user_story_
 from app.api.userStory.service.get_user_story import get_user_story_
@@ -38,3 +39,7 @@ def get_backlog_list(room_id: str, current_user: UserResponse = Depends(get_curr
 def get_current_user_story(session: Session = db_session, ):
     return get_current_user_story_(session=session,)
     
+
+@router.post('/fill_sprint_by_their_user_stories')
+def fill_sprint_by_their_user_stories(user_stories_ids: list[str],sprint_id: str, session: Session = db_session):
+    return fill_sprint_by_their_user_stories_(user_stories_ids=user_stories_ids ,sprint_id=sprint_id, session=session, )

--- a/app/api/userStory/service/fill_sprint_by_their_user_stories_.py
+++ b/app/api/userStory/service/fill_sprint_by_their_user_stories_.py
@@ -1,0 +1,21 @@
+from app.api.room.enums import SprintStatus
+from app.api.room.model import Sprint, UserStory
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+
+def fill_sprint_by_their_user_stories_(user_stories_ids: list[str], sprint_id: str, session: Session):
+    stmt = select(Sprint).where(Sprint.id == sprint_id, Sprint.status == SprintStatus.PLANNED)
+    sprint: Sprint | None = session.execute(stmt).scalar_one_or_none()
+
+    if sprint is None:
+        raise Exception('not found any sprint')
+
+    user_stories = session.execute(
+        select(UserStory).where(UserStory.id.in_(user_stories_ids))
+    ).scalars().all()
+
+    for user_story in user_stories:
+        user_story.sprint_id = sprint_id
+
+    session.commit()

--- a/app/api/userStory/service/get_user_story.py
+++ b/app/api/userStory/service/get_user_story.py
@@ -10,7 +10,7 @@ def get_user_story_(session:Session):
     
 
     
-    user_story = select(UserStory)
+    user_story = select(UserStory).where(UserStory.sprint_id == None)
     story = session.execute(user_story).scalars().all()
     
     return story


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoint to assign multiple user stories to a sprint. Sprint must be in PLANNED status to accept stories.

* **Improvements**
  * User story retrieval now correctly filters to only return unassigned stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->